### PR TITLE
carbon.conf.example - Cleanup whitespace and fix comment

### DIFF
--- a/conf/carbon.conf.example
+++ b/conf/carbon.conf.example
@@ -183,7 +183,6 @@ WHISPER_AUTOFLUSH = False
 # receiver, set this to False
 # LOG_LISTENER_CONN_SUCCESS = True
 
-
 [relay]
 LINE_RECEIVER_INTERFACE = 0.0.0.0
 LINE_RECEIVER_PORT = 2013
@@ -253,7 +252,6 @@ QUEUE_LOW_WATERMARK_PCT = 0.8
 # other batching advantages, all writes are deferred by putting them into a queue,
 # and then the queue is flushed and sent a small fraction of a second later.
 TIME_TO_DEFER_SENDING = 0.0001
-
 
 # Set this to False to drop datapoints when any send queue (sending datapoints
 # to a downstream carbon daemon) hits MAX_QUEUE_SIZE. If this is True (the
@@ -377,7 +375,7 @@ MAX_AGGREGATION_INTERVALS = 5
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
 # CARBON_METRIC_INTERVAL = 60
-#
+
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False
 # LOG_LISTENER_CONN_SUCCESS = True


### PR DESCRIPTION
Just a minor whitespace tidy-up and a comment update.
